### PR TITLE
Style output

### DIFF
--- a/src/components/Detail/detail.module.scss
+++ b/src/components/Detail/detail.module.scss
@@ -3,49 +3,92 @@
 
 .detail {
   flex: 3;
-  padding: ms(3);
+  font-family: 'Dia';
+  padding: ms(2) ms(3) ms(3) ms(3);
 }
 
-@media print, screen {
-  .skill {
-    margin-bottom: ms(3);
-  }
+.header {
+  font-family: 'Dia-Black';
+  font-size: ms(0);
+  letter-spacing: ms(-9);
+  text-align: center;
+  text-transform: uppercase;
+}
 
-  .skillName,
-  .skillLevel {
-    font-size: ms(0);
-    margin: 0 0 ms(-2);
-    display: inline-block;
-  }
+.chart {
+  border-bottom: 1px solid $gray-30;
+  border-top: 1px solid $gray-30;
+  padding: ms(-3) 0;
+  position: relative;
+  width: 100%;
+}
 
-  .skillLevel {
-    font-family: monospace;
-    font-weight: 300;
-    margin-left: ms(0);
-  }
+.dividers {
+  display: flex;
+  height: 100%;
+  justify-content: space-between;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
 
-  .levelNumber {
-    font-family: monospace;
-    font-weight: 800;
-    color: white;
-    display: inline-block;
-    padding: ms(-3);
-  }
+.divider {
+  background: $gray-30;
+  flex: none;
+  height: 100%;
+  width: 1px;
+}
 
-  .levelBar {
-    display: block;
-    height: ms(3);
+.skills {
+  position: relative;
+}
 
-    &.notApplicable {
-      display: none;
-    }
+.skill {
+  position: relative;
+}
+
+.skillName {
+  font-size: ms(-1);
+  display: inline-block;
+  font-weight: 400;
+  margin: 0 0 0 ms(0);
+}
+
+.skillName {
+  color: white;
+  position: absolute;
+  top: ms(2);
+}
+
+.levelBar {
+  display: block;
+  height: ms(5);
+  padding: ms(-3) 0;
+}
+
+.levelBlock {
+  background-color: $ultramarine;
+  display: inline-block;
+  height: 100%;
+  text-align: right;
+  width: 25%;
+}
+
+.notApplicable {
+  + .skillName {
+    color: $gray-40;
   }
 
   .levelBlock {
-    text-align: right;
-    background-color: $ultramarine;
-    display: inline-block;
-    height: 100%;
-    width: 25%;
+    background: none;
   }
+}
+
+.labels {
+  display: flex;
+  font-weight: 700;
+  justify-content: space-around;
+  margin-top: ms(-1);
+  width: 100%;
 }

--- a/src/components/Detail/index.js
+++ b/src/components/Detail/index.js
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { ViewContext } from 'components';
 import { className } from 'utils';
+import { options } from 'data';
 import styles from './detail.module.scss';
 
 const Detail = ({ className: customClassName, }) => {
@@ -9,25 +10,36 @@ const Detail = ({ className: customClassName, }) => {
 
   return (
     <section {...className(customClassName, styles.detail)}>
-      {Object.keys(state).map((skill, i) => (
-        <article key={i} className={styles.skill}>
-          <h1 className={styles.skillName}>{state[skill].displayText}</h1>
-          <h2 className={styles.skillLevel}>{state[skill].level}</h2>
-          <div {...className(styles.levelBar, isNaN(state[skill].level) && styles.notApplicable)}>
-            {[...Array(state[skill].level)].map((undefined, idx) => (
-              <div key={`${idx}-of-${skill}`} className={styles.levelBlock}>
-                <span
-                  {...className(
-                    styles.levelNumber,
-                    state[skill].level === idx && styles.currentLevel
-                  )}>
-                  {idx + 1}
-                </span>
+      <h1 className={styles.header}>Performance Chart</h1>
+      <div className={styles.chart}>
+        <div className={styles.dividers}>
+          {options.map((option, i) => (
+            <div className={styles.divider} key={`divider-${i}`} />
+          ))}
+        </div>
+        <div className={styles.skills}>
+          {Object.keys(state).map((skill, i) => (
+            <article key={i} className={styles.skill}>
+              <div
+                {...className(styles.levelBar, isNaN(state[skill].level) && styles.notApplicable)}>
+                {[...Array(state[skill].level)].map((undefinedPlaceholder, idx) => (
+                  <div key={`${idx}-of-${skill}`} className={styles.levelBlock} />
+                ))}
               </div>
-            ))}
-          </div>
-        </article>
-      ))}
+              <h1 className={styles.skillName}>{state[skill].displayText}</h1>
+            </article>
+          ))}
+        </div>
+      </div>
+      <div className={styles.labels}>
+        {options.map((option, i) => {
+          if (i > 0) {
+            return <span key={`skill-label-${i}`}>{option.displayText}</span>;
+          } else {
+            return '';
+          }
+        })}
+      </div>
     </section>
   );
 };

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -1,12 +1,26 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Detail, Master } from 'components';
+import { className } from 'utils';
 import styles from './layout.module.scss';
 
 const Layout = () => {
+  const [masterIsHidden, setMasterIsHidden] = useState(false);
+
+  const toggleMaster = () => {
+    setMasterIsHidden(!masterIsHidden);
+  };
+
   return (
     <main className={styles.main}>
-      <Master className={styles.master} />
-      <Detail className={styles.detail} />
+      <button
+        onClick={toggleMaster}
+        {...className(styles.showHideBtn, masterIsHidden && styles.show)}>
+        {masterIsHidden ? 'Show Controls' : 'Hide Controls'}
+      </button>
+      <div className={styles.layout}>
+        <Master {...className(styles.master, masterIsHidden && styles.hidden)} />
+        <Detail className={styles.detail} />
+      </div>
     </main>
   );
 };

--- a/src/components/Layout/layout.module.scss
+++ b/src/components/Layout/layout.module.scss
@@ -1,6 +1,13 @@
-.main {
+@import '../../styles/functions/ms';
+@import '../../styles/mixins/button-reset';
+@import '../../styles/mixins/transitions';
+@import '../../styles/variables/colors';
+
+$toggle-btn-height: ms(3);
+
+.layout {
   display: flex;
-  height: 100vh;
+  height: calc(100vh - #{$toggle-btn-height});
   overflow: hidden;
 }
 
@@ -9,8 +16,41 @@
   overflow-y: scroll;
 }
 
-@media print {
-  .master {
-    display: none;
+.master {
+  position: relative;
+}
+
+.master.hidden {
+  display: none;
+}
+
+.showHideBtn {
+  @include button-reset;
+  @include transition;
+
+  background: $gray-80;
+  color: white;
+  display: block;
+  font-size: ms(-2);
+  font-weight: 500;
+  height: $toggle-btn-height;
+  left: 0;
+  padding-left: ms(3);
+  position: sticky;
+  text-align: left;
+  text-transform: uppercase;
+  top: 0;
+  width: 100%;
+
+  &:hover {
+    color: $ultramarine;
+  }
+
+  &.show {
+    opacity: 0;
+
+    &:hover {
+      opacity: 1;
+    }
   }
 }

--- a/src/components/Master/index.js
+++ b/src/components/Master/index.js
@@ -2,33 +2,11 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { ViewContext, Select } from 'components';
 import { className } from 'utils';
+import { options } from 'data';
 import styles from './master.module.scss';
 
 const Master = ({ children, className: customClassName, }) => {
   const [state, setState] = useContext(ViewContext);
-
-  const options = [
-    {
-      displayText: "I don't know.",
-      optValue: 'n/a',
-    },
-    {
-      displayText: 'Needs Improvement',
-      optValue: 1,
-    },
-    {
-      displayText: 'Learning & Building',
-      optValue: 2,
-    },
-    {
-      displayText: 'Full/Consistent Impact',
-      optValue: 3,
-    },
-    {
-      displayText: 'Exceptional Impact',
-      optValue: 4,
-    }
-  ];
 
   const updateContext = (property, value) => {
     const update = {};

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -1,1 +1,2 @@
 export { default as defaults } from './defaults';
+export { default as options } from './options';

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -1,0 +1,24 @@
+const options = [
+  {
+    displayText: "I don't know.",
+    optValue: 'n/a',
+  },
+  {
+    displayText: 'Needs Improvement',
+    optValue: 1,
+  },
+  {
+    displayText: 'Learning & Building',
+    optValue: 2,
+  },
+  {
+    displayText: 'Full/Consistent Impact',
+    optValue: 3,
+  },
+  {
+    displayText: 'Exceptional Impact',
+    optValue: 4,
+  }
+];
+
+export default options;


### PR DESCRIPTION
* Adds button to toggle master controls
* Extracts options to a file in `/data` directory
* Styles output to mimic keynote slides [here](https://docs.google.com/document/d/1g8oUdMb769uRNbNvAippKdiN2JsKHjq4-1ByYvoEalc/edit#)
<img width="450" alt="Screen Shot 2019-10-24 at 4 41 49 PM" src="https://user-images.githubusercontent.com/18580335/67523690-3316fc00-f67d-11e9-8b1c-9e1525e71828.png">


<img width="450" alt="Screen Shot 2019-10-24 at 4 40 25 PM" src="https://user-images.githubusercontent.com/18580335/67523633-14b10080-f67d-11e9-9ffd-770af3100237.png">
<img width="450" alt="Screen Shot 2019-10-24 at 4 40 28 PM" src="https://user-images.githubusercontent.com/18580335/67523634-14b10080-f67d-11e9-87b3-108b1886ff33.png">
